### PR TITLE
build activation scripts for rust 1.79.0.dev20240328

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,4 @@
+upload_channels:
+  - sfe1ed40
+channels:
+  - http://staging.continuum.io/prefect/fs/rust-feedstock/pr8/45baf33

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,2 @@
 upload_channels:
   - sfe1ed40
-channels:
-  - http://staging.continuum.io/prefect/fs/rust-feedstock/pr8/790f05b

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,4 +1,4 @@
 upload_channels:
   - sfe1ed40
 channels:
-  - http://staging.continuum.io/prefect/fs/rust-feedstock/pr8/45baf33
+  - http://staging.continuum.io/prefect/fs/rust-feedstock/pr8/790f05b

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,7 +35,7 @@ outputs:
     script: bld-gnu.bat  # [win]
     requirements:  # [win]
       run:  # [win]
-        - rust-gnu >{{ lower_bound_version }},<{{ version_stable }}  # [win]
+        - rust-gnu ==1.79.0.dev20240328  # [win]
         - m2w64-toolchain  # [win]
     test:  # [win]
       files:  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,7 +35,7 @@ outputs:
     script: bld-gnu.bat  # [win]
     requirements:  # [win]
       run:  # [win]
-        - rust-gnu ==1.79.0.dev20240328  # [win]
+        - rust-gnu =={{ version }}  # [win]
         - m2w64-toolchain  # [win]
     test:  # [win]
       files:  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,6 @@
-{% set version = "1.76.0.dev20231115" %}
+{% set lower_bound_version = "1.75.0" %}
+{% set version_stable = "1.76.0" %}
+{% set version = version_stable + ".dev20231115" %}
 
 package:
   name: rust_{{ target_platform }}-suite
@@ -18,7 +20,7 @@ outputs:
             - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.12") }}  # [osx and x86_64]
     requirements:
       run:
-        - rust >={{ version }}.0a0,<{{ version }}
+        - rust >{{ lower_bound_version }},<{{ version_stable }}
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
     test:
@@ -32,7 +34,7 @@ outputs:
     script: bld-gnu.bat  # [win]
     requirements:  # [win]
       run:  # [win]
-        - rust-gnu >={{ version }}.0a0,<{{ version }}  # [win]
+        - rust-gnu >{{ lower_bound_version }},<{{ version_stable }}  # [win]
         - m2w64-toolchain  # [win]
     test:  # [win]
       files:  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.76.0" %}
+{% set version = "1.76.0.dev20231115" %}
 
 package:
   name: rust_{{ target_platform }}-suite
@@ -18,7 +18,7 @@ outputs:
             - __osx >={{ MACOSX_DEPLOYMENT_TARGET|default("10.12") }}  # [osx and x86_64]
     requirements:
       run:
-        - rust >={{ version }}
+        - rust >={{ version }}.0a0,<{{ version }}
         - {{ compiler('c') }}
         - {{ compiler('cxx') }}
     test:
@@ -32,7 +32,7 @@ outputs:
     script: bld-gnu.bat  # [win]
     requirements:  # [win]
       run:  # [win]
-        - rust-gnu >={{ version }}  # [win]
+        - rust-gnu >={{ version }}.0a0,<{{ version }}  # [win]
         - m2w64-toolchain  # [win]
     test:  # [win]
       files:  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,6 +8,7 @@ package:
 
 build:
   number: 0
+  skip: True  # [s390x]
 
 outputs:
   - name: rust_{{ target_platform }}
@@ -53,7 +54,7 @@ about:
     Rust is a systems programming language that runs blazingly fast,
     prevents segfaults, and guarantees thread safety.
   doc_url: https://www.rust-lang.org/learn
-  dev_url: https://github.com/rust-lang
+  dev_url: https://github.com/rust-lang/rust
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
-{% set lower_bound_version = "1.75.0" %}
-{% set version_stable = "1.76.0" %}
-{% set version = version_stable + ".dev20231115" %}
+{% set lower_bound_version = "1.79.0.dev0" %}
+{% set version_stable = "1.79.0" %}
+{% set version = version_stable + ".dev20240328" %}
 
 package:
   name: rust_{{ target_platform }}-suite


### PR DESCRIPTION
rust-activation 1.79.0.dev20240328 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-4337] 
- [Upstream repository](https://github.com/rust-lang/rust)
- Relevant PRs:
  - [rust-feedstock](https://github.com/AnacondaRecipes/rust-feedstock/pull/8)

### Explanation of changes:

- this activation script points to a nightly release of `1.79.0` necessary for [polars](https://anaconda.atlassian.net/browse/PKG-4133)
- upgraded to **20240328** nightly because recently released `polars 0.20.18` requires


[PKG-4337]: https://anaconda.atlassian.net/browse/PKG-4337?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ