### PR TITLE
update rust-activation with arch-specific toolchain paths

### DIFF
--- a/recipe/activate.sh
+++ b/recipe/activate.sh
@@ -27,7 +27,7 @@ fi
 # detect wasm32 toolchain
 wasm32dir = "${CONDA_PREFIX}/lib/rustlib/wasm32-wasip*"
 if [[ -d ${wasm32dir} ]]; then
-    export RUSTFLAGS="-L ${CONDA_PREFIX}/lib/rustlib/${wasm32dir}/lib"
+    export RUSTFLAGS="-L ${wasm32dir}/lib"
 fi
 
 [[ -d ${CARGO_HOME} ]] || mkdir -p ${CARGO_HOME}

--- a/recipe/activate.sh
+++ b/recipe/activate.sh
@@ -4,6 +4,30 @@ export CARGO_HOME=${CONDA_PREFIX}/.cargo.$(uname)
 export CARGO_CONFIG=${CARGO_HOME}/config
 export RUSTUP_HOME=${CARGO_HOME}/rustup
 
+OS=$(uname)
+ARCH=$(uname -p)
+
+if [[ "$OS" == "Linux" && "$ARCH" == "aarch64" ]]; then
+    rust_arch="aarch64-unknown-linux-gnu"
+elif [[ "$OS" == "Linux" && "$ARCH" == "x86_64" ]]; then
+    rust_arch="x86_64-unknown-linux-gnu"
+elif [[ "$OS" == "Darwin" && "$ARCH" == "i386" ]]; then
+    rust_arch="x86_64-apple-darwin"
+elif [[ "$OS" == "Darwin" && "$ARCH" == "arm" ]]; then
+    rust_arch="aarch64-apple-darwin"
+else
+    rust_arch=""
+fi
+
+if [[ -n "$rust_arch" && -d ${CONDA_PREFIX}/lib/rustlib/${rust_arch} ]]; then
+    export RUSTFLAGS="-L ${CONDA_PREFIX}/lib/rustlib/${rust_arch}/lib"
+fi
+
+wasm32dir = "${CONDA_PREFIX}/lib/rustlib/wasm32-wasip1"
+if [[ -d ${wasm32dir} ]]; then
+    export RUSTFLAGS="-L ${CONDA_PREFIX}/lib/rustlib/${wasm32dir}/lib"
+fi
+
 [[ -d ${CARGO_HOME} ]] || mkdir -p ${CARGO_HOME}
 
 if [[ $(uname) == Darwin ]]; then

--- a/recipe/activate.sh
+++ b/recipe/activate.sh
@@ -19,11 +19,13 @@ else
     rust_arch=""
 fi
 
+# set flags for arch-dependent rust-std toolchain
 if [[ -n "$rust_arch" && -d ${CONDA_PREFIX}/lib/rustlib/${rust_arch} ]]; then
     export RUSTFLAGS="-L ${CONDA_PREFIX}/lib/rustlib/${rust_arch}/lib"
 fi
 
-wasm32dir = "${CONDA_PREFIX}/lib/rustlib/wasm32-wasip1"
+# detect wasm32 toolchain
+wasm32dir = "${CONDA_PREFIX}/lib/rustlib/wasm32-wasip*"
 if [[ -d ${wasm32dir} ]]; then
     export RUSTFLAGS="-L ${CONDA_PREFIX}/lib/rustlib/${wasm32dir}/lib"
 fi


### PR DESCRIPTION
rust-activation 1.82.0

**Destination channel:** Defaults
### Links

- [PKG-7330]
- dev_url:        https://github.com/rust-lang/rust/tree/1.82.0
- conda_forge:    https://github.com/conda-forge/rust-activation-feedstock
- pypi:           None
- pypi inspector: None

### Explanation of changes:

- rebuild to include paths for arch-specific, `wasm-wapi1` and `wasm-wapi2` toolchains.


[PKG-6385]: https://anaconda.atlassian.net/browse/PKG-6385?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[PKG-7279]: https://anaconda.atlassian.net/browse/PKG-7279?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ