### PR TITLE
PKG-12507: PKG-12506_rust_activation 1.93.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 # !! update of rust-activation version should be carried out together with rust version update !!
 # https://github.com/AnacondaRecipes/rust-feedstock
-{% set version = "1.90.0" %}
+{% set version = "1.93.1" %}
 
 package:
   name: rust_{{ target_platform }}-suite


### PR DESCRIPTION
rust-activation 1.93.1

**Destination channel:** defaults

### Links

- [PKG-12507](https://anaconda.atlassian.net/browse/PKG-12507) 
- [Upstream repository](https://github.com/rust-lang/rust/tree/1.93.1)
### Explanation of changes:

- New version number

[PKG-12507]: https://anaconda.atlassian.net/browse/PKG-12507?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ