### PR TITLE
rust-nightly-activation 1.96.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,7 +1,7 @@
 # !! update of rust-activation version should be carried out together with rust version update !!
 # https://github.com/AnacondaRecipes/rust-feedstock
-{% set date = "2026-02-06" %}
-{% set version = "1.95.0_" ~ date.replace('-', '_') %}
+{% set date = "2026-04-01" %}
+{% set version = "1.96.0_" ~ date.replace('-', '_') %}
 
 package:
   name: rust-nightly_{{ target_platform }}


### PR DESCRIPTION
rust-nightly-activation

target channel: defaults

[source url](https://forge.rust-lang.org/infra/other-installation-methods.html)